### PR TITLE
Add CI to project

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,26 @@
+name: GO server Continous Integration Workflow
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-ci.yml"
+      - "!**/*.md"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "^1.13.1"
+      - name: "Install dependencies"
+        run: go mod tidy
+      - run: go test ./...

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -22,8 +22,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - name: "Install dependencies"
-        run: go mod tidy
       - run: go test ./...
   golangci:
     name: lint

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           go-version: 1.19
       - uses: actions/checkout@v3
-      - run: go mod tidy
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
     branches:
       - main
+      - develop
     paths:
       - "backend/**"
       - ".github/workflows/backend-ci.yml"

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,7 +11,7 @@ on:
       - "!**/*.md"
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -20,8 +20,25 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.13.1"
+          go-version: 1.19
       - name: "Install dependencies"
         run: go mod tidy
       - run: go test ./...
-      - run: docker build -t backend/dev:latest .
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v3
+      - run: go mod tidy
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.48
+          skip-cache: true
+          working-directory: backend

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -24,3 +24,4 @@ jobs:
       - name: "Install dependencies"
         run: go mod tidy
       - run: go test ./...
+      - run: docker build -t backend/dev:latest .

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,27 @@
+name: React.JS Continous Integration Workflow
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+      - "!**/*.md"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend/smart-kickers-game
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: "Install dependencies"
+        run: npm ci
+      - run: npm test
+      - name: "Build docker image"
+        run: docker build -t frontend/dev:latest .

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -2,11 +2,7 @@ name: React.JS Continous Integration Workflow
 
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+    types: [opened, reopened, synchronize, ready_for_review]
     branches:
       - main
       - develop

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -12,18 +12,28 @@ on:
       - "!**/*.md"
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./frontend/smart-kickers-game
     steps:
-      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+      - uses: actions/checkout@v3
       - name: "Install dependencies"
         run: npm ci
       - run: npm test
-      - name: "Build docker image"
-        run: docker build -t frontend/dev:latest .
+
+  prettier:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend/smart-kickers-game
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - uses: actions/checkout@v3
+      - run: npx prettier --check .

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -2,8 +2,14 @@ name: React.JS Continous Integration Workflow
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
+      - develop
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"


### PR DESCRIPTION
## Summary of Changes
I added a simple CI for our project which tests code automatically using Github actions.

### Workflow Step By Step

Both workflows contain two jobs: one for running unit tests and a second for running linters.

The job for tests contains these steps:
 1. Setup go/node according to changed files
 2. Checkout code from repository/PR
 3. Install dependencies
 4. Run tests
 
The job for static code checkers contains these steps:
 1. Setup go/node
 2. Checkout code from repository/PR
 3. Run static code checkers tools
 
 ## Known Limitations
 1. Node/Go version should be written in matrix or env variable, but for now it's not necessary in my opinion