### PR TITLE
Add ball position reading

### DIFF
--- a/backend/internal/controller/adapter/dispatcher.go
+++ b/backend/internal/controller/adapter/dispatcher.go
@@ -18,6 +18,8 @@ type Message struct {
 	Category MsgCategory
 	TableID  string
 	Team     int
+	X        float64
+	Y        float64
 }
 
 type dispatcherMsg struct {
@@ -48,6 +50,8 @@ func UnpackDispatcherMsg(message io.Reader) (Message, error) {
 		Category: tableMessage.getMessageCategory(),
 		TableID:  tableMessage.TableID,
 		Team:     tableMessage.Goal,
+		X:        tableMessage.X,
+		Y:        tableMessage.Y,
 	}, nil
 }
 
@@ -58,7 +62,7 @@ func (dispMsg dispatcherMsg) getMessageCategory() MsgCategory {
 	if dispMsg.Goal != 0 {
 		return MsgGoal
 	}
-	return MsgNone
+	return MsgPosition
 }
 
 func NewDispatcherResponse(tableID string) *initialResponse {

--- a/backend/internal/controller/adapter/dispatcher.go
+++ b/backend/internal/controller/adapter/dispatcher.go
@@ -62,7 +62,10 @@ func (dispMsg dispatcherMsg) getMessageCategory() MsgCategory {
 	if dispMsg.Goal != 0 {
 		return MsgGoal
 	}
-	return MsgPosition
+	if dispMsg.MsgType == "" {
+		return MsgPosition
+	}
+	return MsgNone
 }
 
 func NewDispatcherResponse(tableID string) *initialResponse {

--- a/backend/internal/controller/adapter/dispatcher_test.go
+++ b/backend/internal/controller/adapter/dispatcher_test.go
@@ -35,14 +35,14 @@ func TestGetMessageCategory(t *testing.T) {
 			},
 			expectedCategory: MsgGoal},
 		{
-			name: "position message, should return MsgNone",
+			name: "position message, should return MsgPosition",
 			msg: dispatcherMsg{
 				MsgType: "",
 				Goal:    0,
 				X:       4,
 				Y:       2.22,
 			},
-			expectedCategory: MsgNone},
+			expectedCategory: MsgPosition},
 		{
 			name: "unexpected message, should return MsgNone",
 			msg: dispatcherMsg{
@@ -108,9 +108,11 @@ func TestUnpackDispatcherMsg(t *testing.T) {
 				Y:       1.25,
 			},
 			ExpectedMsgOut: Message{
-				Category: MsgNone,
+				Category: MsgPosition,
 				TableID:  "5",
 				Team:     0,
+				X:        14.3,
+				Y:        1.25,
 			},
 		},
 		{
@@ -126,6 +128,8 @@ func TestUnpackDispatcherMsg(t *testing.T) {
 				Category: MsgNone,
 				TableID:  "Random",
 				Team:     0,
+				X:        14.3,
+				Y:        1.25,
 			},
 		},
 	}

--- a/backend/internal/controller/server/msg_handler.go
+++ b/backend/internal/controller/server/msg_handler.go
@@ -68,7 +68,7 @@ func (s server) createResponse(reader io.Reader) ([]byte, error) {
 		err := s.game.AddGoal(message.Team)
 		return nil, err
 	case adapter.MsgPosition:
-		log.Trace("X: ", message.X, " Y: ", message.Y)
+		log.Trace("X coord of the ball: ", message.X, " Y coord of the ball: ", message.Y)
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("unrecognized message type %d", message.Category)

--- a/backend/internal/controller/server/msg_handler.go
+++ b/backend/internal/controller/server/msg_handler.go
@@ -67,6 +67,9 @@ func (s server) createResponse(reader io.Reader) ([]byte, error) {
 	case adapter.MsgGoal:
 		err := s.game.AddGoal(message.Team)
 		return nil, err
+	case adapter.MsgPosition:
+		log.Trace("X: ", message.X, " Y: ", message.Y)
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unrecognized message type %d", message.Category)
 	}

--- a/backend/internal/controller/server/msg_handler_test.go
+++ b/backend/internal/controller/server/msg_handler_test.go
@@ -56,13 +56,14 @@ func TestCreateResponse(t *testing.T) {
 		{
 			name: "position message",
 			msgIn: dispatcherMsg{
+				MsgType: "",
 				Goal:    0,
 				TableID: "5",
 				X:       14.3,
 				Y:       1.25,
 			},
 			returnsNil:    true,
-			expectedError: "unrecognized message type 0",
+			expectedError: "",
 		},
 		{
 			name: "unexpected message",


### PR DESCRIPTION
* Reads received ball position from node, that will be used for heatmap generation.
* Fixes test for msg_handler.go after adding the ball position reading.
* Fixes test for dispatcher.go after adding the ball position reading.