### PR TITLE
Update image name in k8s deployment definition for go

### DIFF
--- a/backend/k8s-deployment.yml
+++ b/backend/k8s-deployment.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: gosmartkickers
-          image: marekkawalski/smartkickers:latest
+          image: ghcr.io/hackyourcareer/smartkickers-backend:latest
           ports:
             - containerPort: 3000
           imagePullPolicy: Always


### PR DESCRIPTION
Change image name to utilize our GHCR registry instead of Marek private docker hub registry.