### PR TITLE
Remove wsl from golangci-lint config

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -34,7 +34,6 @@ linters:
     - unparam
     - varcheck
     - whitespace
-    - wsl
 
 linters-settings:
   goconst:


### PR DESCRIPTION
## Summary of Changes

Removed WSL from golangci-linter configuration

## Reasons for change

WSL linter is one of the most aggressive linter available in golangci-lint, and it provides some false-positivies in CI workflows.

Fixes: #177 