### PR TITLE
Optimize heatmap generating on frontend

### DIFF
--- a/backend/internal/model/game.go
+++ b/backend/internal/model/game.go
@@ -213,7 +213,7 @@ func (g *game) IncrementHeatmap(xCord float64, yCord float64) error {
 			for j := y - 1; j <= y+1; j++ {
 				if i > 0 && i < heatmapUpperBound {
 					if j > 0 && j < heatmapUpperBound {
-						g.gameData.Heatmap[i][j]++
+						g.gameData.Heatmap[j][i]++
 					}
 				}
 			}
@@ -221,11 +221,11 @@ func (g *game) IncrementHeatmap(xCord float64, yCord float64) error {
 	} else {
 		for i := x - 1; i <= x+1; i++ {
 			for j := y - 1; j <= y+1; j++ {
-				g.gameData.Heatmap[i][j]++
+				g.gameData.Heatmap[j][i]++
 			}
 		}
 	}
-	g.gameData.Heatmap[x][y]++
+	g.gameData.Heatmap[y][x]++
 
 	return nil
 }

--- a/backend/internal/model/game_test.go
+++ b/backend/internal/model/game_test.go
@@ -286,7 +286,7 @@ func TestIncrementHeatmap(t *testing.T) {
 				for j := y - 1; j <= y+1; j++ {
 					if i > 0 && i < heatmapUpperBound {
 						if j > 0 && j < heatmapUpperBound {
-							game.gameData.Heatmap[i][j] = tt.startingHeatmapValue
+							game.gameData.Heatmap[j][i] = tt.startingHeatmapValue
 						}
 					}
 				}
@@ -297,10 +297,10 @@ func TestIncrementHeatmap(t *testing.T) {
 					for j := y - 1; j <= y+1; j++ {
 						if i > 0 && i < heatmapUpperBound {
 							if j > 0 && j < heatmapUpperBound {
-								if i == x && j == y {
-									assert.Equal(t, tt.expectedHeatmapMainValue, game.gameData.Heatmap[i][j])
+								if j == y && i == x {
+									assert.Equal(t, tt.expectedHeatmapMainValue, game.gameData.Heatmap[j][i])
 								} else {
-									assert.Equal(t, tt.expectedHeatmapAdjacentValue, game.gameData.Heatmap[i][j])
+									assert.Equal(t, tt.expectedHeatmapAdjacentValue, game.gameData.Heatmap[j][i])
 								}
 							}
 						}

--- a/frontend/smart-kickers-game/src/components/Heatmap/Heatmap.js
+++ b/frontend/smart-kickers-game/src/components/Heatmap/Heatmap.js
@@ -15,7 +15,7 @@ function Heatmap() {
         <HeatMap
           xLabels={heatmap.array}
           yLabels={heatmap.array}
-          data={heatmap.numbersCopy}
+          data={heatmap.numbers}
           cellStyle={(background, value, min, max) => ({
             background: `${chooseColor(value)} `,
             fontSize: '0px',

--- a/frontend/smart-kickers-game/src/hooks/useHeatmap.js
+++ b/frontend/smart-kickers-game/src/hooks/useHeatmap.js
@@ -2,13 +2,6 @@ import useAxios from 'axios-hooks';
 import config from '../config';
 import { useMemo } from 'react';
 
-function mirrorHeatmap(data) {
-  const heatmapDim = data.length;
-  const array = new Array(heatmapDim).fill('');
-
-  return { array, numbersCopy: data };
-}
-
 const useHeatmap = () => {
   const [{ data, loading, error }] = useAxios(
     {
@@ -17,7 +10,7 @@ const useHeatmap = () => {
     },
     { useCache: false }
   );
-  const heatmap = useMemo(() => data && mirrorHeatmap(data.heatmap), [data]);
+  const heatmap = useMemo(() => data && { array: new Array(data.heatmap.length).fill(''), numbersCopy: data.heatmap }, [data]);
 
   return { loading, error, heatmap };
 };

--- a/frontend/smart-kickers-game/src/hooks/useHeatmap.js
+++ b/frontend/smart-kickers-game/src/hooks/useHeatmap.js
@@ -5,19 +5,8 @@ import { useMemo } from 'react';
 function mirrorHeatmap(data) {
   const heatmapDim = data.length;
   const array = new Array(heatmapDim).fill('');
-  const transpose = (matrix) => {
-    const numbersCopy = structuredClone(matrix);
-    for (let row = 0; row < numbersCopy.length; row++) {
-      for (let column = 0; column < row; column++) {
-        let temp = numbersCopy[row][column];
-        numbersCopy[row][column] = numbersCopy[column][row];
-        numbersCopy[column][row] = temp;
-      }
-    }
-    return numbersCopy;
-  };
 
-  return { array, numbersCopy: transpose(data) };
+  return { array, numbersCopy: data };
 }
 
 const useHeatmap = () => {

--- a/frontend/smart-kickers-game/src/hooks/useHeatmap.js
+++ b/frontend/smart-kickers-game/src/hooks/useHeatmap.js
@@ -10,7 +10,7 @@ const useHeatmap = () => {
     },
     { useCache: false }
   );
-  const heatmap = useMemo(() => data && { array: new Array(data.heatmap.length).fill(''), numbersCopy: data.heatmap }, [data]);
+  const heatmap = useMemo(() => data && { array: new Array(data.heatmap.length).fill(''), numbers: data.heatmap }, [data]);
 
   return { loading, error, heatmap };
 };


### PR DESCRIPTION
Currently the heatmap matrix is transposed on frontend to allow to generate it. It is possible to generate an already transposed matrix on the backend while collecting the data. It allows to remove an O(n<sup>2</sup>) loop from frontend without moving it to backend.

List of changes:
* Remove matrix transpose from frontend
* Change the way the heatmap data is collected on backend 
* Adjust heatmap test